### PR TITLE
Reuse device variable on torch_compile

### DIFF
--- a/torch_compile.py
+++ b/torch_compile.py
@@ -17,7 +17,7 @@ model.to(device)
 tokenizer = AutoTokenizer.from_pretrained(ckpt)
 
 prompt = "Why dogs are so cute?"
-inputs = tokenizer(prompt, return_tensors="pt").to("cuda")
+inputs = tokenizer(prompt, return_tensors="pt").to(device)
 
 # Specify the max length (including both the prompt and the response)
 # When calling `generate` with `cache_implementation="static" later, this is also used to create a `StaticCache` object


### PR DESCRIPTION
Ensuring that the device is consistent everywhere in the file